### PR TITLE
Update fr24 feeder to 1.0.34-0

### DIFF
--- a/fr24/Dockerfile
+++ b/fr24/Dockerfile
@@ -3,8 +3,7 @@ FROM balenalib/rpi-raspbian:buster
 WORKDIR /root
 
 RUN apt-get update && apt-get install -qy iputils-ping telnet ntp wget
-# warning: latest version does not work: fr24feed_1.0.26-9_armhf.deb
-RUN wget https://repo-feed.flightradar24.com/rpi_binaries/fr24feed_1.0.25-3_armhf.deb \
+RUN wget https://repo-feed.flightradar24.com/rpi_binaries/fr24feed_1.0.34-0_armhf.deb \
   && dpkg --unpack fr24feed*.deb && rm -rf fr24feed*.deb
 
 COPY ./fr24feed.ini /etc/fr24feed.ini


### PR DESCRIPTION
FlightRadar24 is phasing out 1.0.25 and sent an email out to feeder hosts asking us to update to 1.0.34. I noted the comment that was here previously indicating that 1.0.26-9 didn't work, but I've tested this latest update on my Pi 1 B+ and it seems to be working fine.

Snippet from the email that was sent to hosts:
> This is a reminder to inform you that we are phasing out the version of FR24 data sharing software that you are currently using (1.0.25-3). We would therefore like you to upgrade to the latest version (1.0.34-0) before Feb 28, 2023