### PR TITLE
Change repo source from git to https

### DIFF
--- a/dump1090fa/Dockerfile
+++ b/dump1090fa/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -qy \
     libterm-readline-perl-perl
 
 # not needed to run dump1090-fa but could be useful for debugging issues
-RUN git clone git://git.osmocom.org/rtl-sdr.git \
+RUN git clone https://git.osmocom.org/rtl-sdr.git \
     && mkdir -p ./rtl-sdr/build \
     && cd /root/rtl-sdr/build \
     && cmake ../ -DINSTALL_UDEV_RULES=ON \


### PR DESCRIPTION
Recently tried to rebuild and it was bailing because it couldn't connect to git://git.osmocom.org  changing to https resolved the issue

```
Cloning into 'rtl-sdr'...
fatal: unable to connect to git.osmocom.org:
git.osmocom.org[0: 78.46.96.155]: errno=Connection refused
git.osmocom.org[1: 2a01:4f8:120:8470::2]: errno=Cannot assign requested address

ERROR: Service 'dump1090fa' failed to build: The command '/bin/sh -c git clone git://git.osmocom.org/rtl-sdr.git     && mkdir -p ./rtl-sdr/build     && cd /root/rtl-sdr/build     && cmake ../ -DINSTALL_UDEV_RULES=ON     && make -j 4     && make install     && ldconfig     && cp /root/rtl-sdr/rtl-sdr.rules /etc/udev/rules.d/' returned a non-zero code: 128
```